### PR TITLE
feat(team): Team エンティティとドメインイベントを実装

### DIFF
--- a/packages/team/src/domain/events.ts
+++ b/packages/team/src/domain/events.ts
@@ -1,0 +1,95 @@
+import type { UnwrapNominalRecord } from "@ponp/fundamental";
+
+import type { Team } from "./team";
+import { TeamId, TeamName } from "./team";
+
+/* ---- イベントタイプ定数 ---- */
+
+/**
+ * チームドメインイベントのタイプを表す定数です。
+ */
+export const TeamEventType = {
+  CREATED: "TEAM_CREATED",
+} as const;
+
+/* ---- 型 ---- */
+
+/**
+ * 新しいチームが作成されたことを表すイベントです。
+ */
+export type TeamCreated = {
+  /**
+   * イベントのタイプです。
+   */
+  type: typeof TeamEventType.CREATED;
+
+  /**
+   * 作成されたチームの識別子です。
+   * @see TeamId
+   */
+  teamId: TeamId;
+
+  /**
+   * 作成されたチームの名前です。
+   * @see TeamName
+   */
+  name: TeamName;
+
+  /**
+   * 作成された日時です。
+   */
+  createdAt: Date;
+};
+
+/**
+ * チームコンテキストのすべてのドメインイベントのユニオンです。
+ */
+export type TeamEvent = TeamCreated;
+
+/* ---- ファクトリ関数 ---- */
+
+/**
+ * チームの作成イベントの再構築に必要なパラメータです。
+ */
+type TeamCreatedReconstructParams = UnwrapNominalRecord<TeamCreated>;
+
+/**
+ * チーム作成イベントのコンストラクタです。
+ *
+ * @param params チーム作成イベントのパラメータです。
+ * @returns チーム作成イベントのインスタンスを返します。
+ */
+export const TeamCreated = (params: TeamCreated) => {
+  // イベント単位でのバリデーションなどがあればここに記述する。
+  return params;
+};
+
+/**
+ * チームの作成イベントのファクトリ関数です。
+ *
+ * @param params チームの作成イベントの再構築に必要なパラメータです。
+ * @returns 値オブジェクトに変換された作成イベントを返します。
+ */
+TeamCreated.reconstruct = (params: TeamCreatedReconstructParams): TeamCreated => {
+  return TeamCreated({
+    type: TeamEventType.CREATED,
+    teamId: TeamId(params.teamId),
+    name: TeamName(params.name),
+    createdAt: params.createdAt,
+  });
+};
+
+/**
+ * 指定したチームに対する作成イベントを作成します。
+ *
+ * @param team 対象のチームです。
+ * @returns 新しい作成イベントを返します。
+ */
+TeamCreated.create = (team: Team): TeamCreated => {
+  return TeamCreated({
+    type: TeamEventType.CREATED,
+    teamId: team.id,
+    name: team.name,
+    createdAt: new Date(),
+  });
+};

--- a/packages/team/src/domain/index.ts
+++ b/packages/team/src/domain/index.ts
@@ -1,2 +1,11 @@
-export { TeamId, TeamName } from "./team";
-export type { TeamId as TeamIdType, TeamName as TeamNameType } from "./team";
+export { Team, TeamId, TeamName } from "./team";
+export type {
+  CreateTeamParams,
+  ReconstructTeamParams,
+  Team as TeamType,
+  TeamId as TeamIdType,
+  TeamName as TeamNameType,
+} from "./team";
+
+export { TeamCreated, TeamEventType } from "./events";
+export type { TeamCreated as TeamCreatedType, TeamEvent } from "./events";


### PR DESCRIPTION
- Team エンティティ（id, name）を追加
- Team.create() でチーム作成とイベント発行
- Team.reconstruct() でリポジトリからの再構築
- TeamCreated ドメインイベントを定義
- 関連テストを追加（10件）

Closes #4