### PR TITLE
`@ponp/notification` パッケージを追加; メール送信サービスのインターフェース定義とコンソール出力実装を含む

### DIFF
--- a/packages/notification/eslint.config.js
+++ b/packages/notification/eslint.config.js
@@ -1,0 +1,4 @@
+import { config } from "@ponp/eslint-config/base";
+
+/** @type {import("eslint").Linter.Config[]} */
+export default config;

--- a/packages/notification/package.json
+++ b/packages/notification/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@ponp/notification",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "module": "src/index.ts",
+  "types": "src/index.ts",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint . --ext .ts,.tsx",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@ponp/fundamental": "workspace:*"
+  },
+  "devDependencies": {
+    "@ponp/eslint-config": "workspace:*",
+    "@ponp/typescript-config": "workspace:*",
+    "eslint": "^9.39.2",
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.16"
+  }
+}

--- a/packages/notification/src/application/index.ts
+++ b/packages/notification/src/application/index.ts
@@ -1,0 +1,2 @@
+export type { EmailService, SendEmailParams } from "./port/email-service";
+export { emailServiceMock } from "./port/email-service.mock";

--- a/packages/notification/src/application/port/email-service.mock.ts
+++ b/packages/notification/src/application/port/email-service.mock.ts
@@ -1,0 +1,14 @@
+import type { Mocked } from "vitest";
+import { vi } from "vitest";
+
+import type { EmailService } from "./email-service";
+
+/**
+ * メール送信サービスのモック実装です。
+ */
+export const emailServiceMock: Mocked<EmailService> = {
+  /**
+   * メールを送信します。
+   */
+  send: vi.fn(),
+};

--- a/packages/notification/src/application/port/email-service.ts
+++ b/packages/notification/src/application/port/email-service.ts
@@ -1,0 +1,35 @@
+/**
+ * メール送信に必要なパラメータです。
+ */
+export type SendEmailParams = {
+  /**
+   * 送信先のメールアドレスです。
+   */
+  to: string;
+
+  /**
+   * メールの件名です。
+   */
+  subject: string;
+
+  /**
+   * メールの本文です。
+   */
+  body: string;
+};
+
+/**
+ * メール送信サービスのインターフェースです。
+ *
+ * @remarks
+ * - 実際のメール送信は infrastructure 層のアダプタで実装します。
+ */
+export type EmailService = {
+  /**
+   * メールを送信します。
+   *
+   * @param params 送信パラメータです。
+   * @throws {InfrastructureError} 送信に失敗した場合にスローされます。
+   */
+  send: (params: SendEmailParams) => Promise<void>;
+};

--- a/packages/notification/src/index.ts
+++ b/packages/notification/src/index.ts
@@ -1,0 +1,45 @@
+import type { EmailService } from "./application";
+import { ConsoleEmailService } from "./infrastructure";
+
+/**
+ * 通知モジュールの依存関係です。
+ */
+type NotificationModuleDependencies = {
+  /**
+   * メール送信サービスです。
+   *
+   * @remarks
+   * - 省略した場合は ConsoleEmailService が使用されます。
+   */
+  emailService?: EmailService;
+};
+
+/**
+ * 通知モジュールの操作関数をまとめた型です。
+ */
+export type NotificationModule = {
+  /**
+   * メール送信サービスです。
+   */
+  emailService: EmailService;
+};
+
+/**
+ * 通知モジュールを作成します。
+ *
+ * @param dependencies 依存関係を指定します。
+ * @returns 通知モジュールを返します。
+ */
+export const createNotificationModule = (
+  dependencies: NotificationModuleDependencies = {},
+): NotificationModule => {
+  const emailService = dependencies.emailService ?? ConsoleEmailService();
+
+  return {
+    emailService,
+  };
+};
+
+export type { EmailService, SendEmailParams } from "./application";
+export { emailServiceMock } from "./application";
+export { ConsoleEmailService } from "./infrastructure";

--- a/packages/notification/src/infrastructure/adapter/console.email-service.test.ts
+++ b/packages/notification/src/infrastructure/adapter/console.email-service.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+import { ConsoleEmailService } from "./console.email-service";
+
+describe("ConsoleEmailService", () => {
+  /**
+   * テスト用の送信先メールアドレスです。
+   */
+  const TEST_TO = "test@example.com";
+
+  /**
+   * テスト用のメール件名です。
+   */
+  const TEST_SUBJECT = "テスト件名";
+
+  /**
+   * テスト用のメール本文です。
+   */
+  const TEST_BODY = "テスト本文です。";
+
+  /**
+   * console.log のスパイです。
+   */
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+  });
+
+  test("メール送信時にコンソールにログを出力する", async () => {
+    const emailService = ConsoleEmailService();
+
+    await emailService.send({
+      to: TEST_TO,
+      subject: TEST_SUBJECT,
+      body: TEST_BODY,
+    });
+
+    expect(consoleSpy).toHaveBeenCalledWith("[Email] 送信:", {
+      to: TEST_TO,
+      subject: TEST_SUBJECT,
+      body: TEST_BODY,
+    });
+  });
+
+  test("複数回呼び出しても正常に動作する", async () => {
+    const emailService = ConsoleEmailService();
+
+    await emailService.send({
+      to: TEST_TO,
+      subject: TEST_SUBJECT,
+      body: TEST_BODY,
+    });
+
+    await emailService.send({
+      to: "another@example.com",
+      subject: "別の件名",
+      body: "別の本文です。",
+    });
+
+    expect(consoleSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/notification/src/infrastructure/adapter/console.email-service.ts
+++ b/packages/notification/src/infrastructure/adapter/console.email-service.ts
@@ -1,0 +1,25 @@
+import type { EmailService, SendEmailParams } from "../../application/port/email-service";
+
+/**
+ * コンソールにメール内容を出力するメールサービスの実装です。
+ *
+ * @remarks
+ * - 開発・テスト環境での利用を想定しています。
+ * - 実際のメール送信は行わず、コンソールにログを出力します。
+ *
+ * @returns コンソール出力のメールサービスを返します。
+ */
+export const ConsoleEmailService = (): EmailService => ({
+  /**
+   * メール内容をコンソールに出力します。
+   *
+   * @param params 送信パラメータです。
+   */
+  async send(params: SendEmailParams): Promise<void> {
+    console.log("[Email] 送信:", {
+      to: params.to,
+      subject: params.subject,
+      body: params.body,
+    });
+  },
+});

--- a/packages/notification/src/infrastructure/index.ts
+++ b/packages/notification/src/infrastructure/index.ts
@@ -1,0 +1,1 @@
+export { ConsoleEmailService } from "./adapter/console.email-service";

--- a/packages/notification/tsconfig.json
+++ b/packages/notification/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "@ponp/typescript-config/service.json",
+  "include": ["src"],
+  "exclude": ["node_modules"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,28 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/notification:
+    dependencies:
+      '@ponp/fundamental':
+        specifier: workspace:*
+        version: link:../fundamental
+    devDependencies:
+      '@ponp/eslint-config':
+        specifier: workspace:*
+        version: link:../eslint-config
+      '@ponp/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      eslint:
+        specifier: ^9.39.2
+        version: 9.39.2
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.0.16
+        version: 4.0.16(@types/node@25.0.3)
+
   packages/participant:
     dependencies:
       '@ponp/event-bus':


### PR DESCRIPTION
- `EmailService` インターフェースと `SendEmailParams` 型を定義
- `ConsoleEmailService` でコンソールにメール内容を出力する実装を追加
- テスト用モック `emailServiceMock` を追加
- `createNotificationModule` でモジュールファクトリを提供