### PR TITLE
feat(team): TeamName に小文字英字のみを許可するバリデーションを追加

### DIFF
--- a/packages/fundamental/src/assertions.ts
+++ b/packages/fundamental/src/assertions.ts
@@ -100,3 +100,23 @@ export function assertStringLength(
 ): asserts value is string {
   assert(value.length <= maxLength, error);
 }
+
+/**
+ * 指定された文字列が正規表現にマッチするかを検証します。
+ *
+ * @param value 検証する文字列です。
+ * @param regex 検証に使用する正規表現です。
+ * @param error 検証に失敗した場合にスローするエラーです。
+ * @throws {ValidationError} 指定した文字列が正規表現にマッチしない場合は指定された ValidationError をスローします。
+ *
+ * @example
+ * assertRegex("abc", /^[a-z]+$/, error); // OK
+ * assertRegex("ABC", /^[a-z]+$/, error); // ValidationError をスロー
+ */
+export function assertRegex(
+  value: string,
+  regex: RegExp,
+  error: ValidationError,
+): asserts value is string {
+  assert(regex.test(value), error);
+}

--- a/packages/team/src/domain/team.test.ts
+++ b/packages/team/src/domain/team.test.ts
@@ -50,6 +50,21 @@ describe("TeamName", () => {
    */
   const TEST_TOO_LONG_NAME = "ab";
 
+  /**
+   * テストに使用する大文字のチーム名です。
+   */
+  const TEST_UPPERCASE_NAME = "A";
+
+  /**
+   * テストに使用する数字のチーム名です。
+   */
+  const TEST_NUMERIC_NAME = "1";
+
+  /**
+   * テストに使用する記号のチーム名です。
+   */
+  const TEST_SYMBOL_NAME = "@";
+
   test("有効な名前から生成できる", () => {
     const teamName = TeamName(TEST_VALID_NAME);
 
@@ -62,6 +77,18 @@ describe("TeamName", () => {
 
   test("1文字を超える場合は ValidationError をスローする", () => {
     expect(() => TeamName(TEST_TOO_LONG_NAME)).toThrow(ValidationError);
+  });
+
+  test("大文字の場合は ValidationError をスローする", () => {
+    expect(() => TeamName(TEST_UPPERCASE_NAME)).toThrow(ValidationError);
+  });
+
+  test("数字の場合は ValidationError をスローする", () => {
+    expect(() => TeamName(TEST_NUMERIC_NAME)).toThrow(ValidationError);
+  });
+
+  test("記号の場合は ValidationError をスローする", () => {
+    expect(() => TeamName(TEST_SYMBOL_NAME)).toThrow(ValidationError);
   });
 });
 

--- a/packages/team/src/domain/team.ts
+++ b/packages/team/src/domain/team.ts
@@ -1,6 +1,7 @@
 import type { UnwrapNominalRecord } from "@ponp/fundamental";
 import {
   assertNonEmptyString,
+  assertRegex,
   assertStringLength,
   assertUUID,
   type Nominal,
@@ -9,6 +10,11 @@ import {
 } from "@ponp/fundamental";
 
 import { TeamCreated } from "./events";
+
+/**
+ * 小文字英字のみを許可する正規表現です。
+ */
+const LOWERCASE_ALPHABETIC_REGEX = /^[a-z]+$/;
 
 /* ---- 型 ---- */
 
@@ -81,6 +87,7 @@ TeamId.generate = () => {
  * @returns 指定された文字列がチームの名前として有効であれば、その文字列を公称型にして返します。
  * @throws {ValidationError} 指定された文字列が空の場合にスローされます。
  * @throws {ValidationError} 指定された文字列が1文字を超える場合にスローされます。
+ * @throws {ValidationError} 指定された文字列が小文字英字以外を含む場合にスローされます。
  */
 export const TeamName = (value: string): TeamName => {
   const emptyError = new ValidationError({
@@ -96,6 +103,13 @@ export const TeamName = (value: string): TeamName => {
     value,
   });
   assertStringLength(value, 1, tooLongError);
+
+  const notLowercaseAlphabeticError = new ValidationError({
+    code: "TEAM_NAME_NOT_LOWERCASE_ALPHABETIC",
+    field: "TeamName",
+    value,
+  });
+  assertRegex(value, LOWERCASE_ALPHABETIC_REGEX, notLowercaseAlphabeticError);
 
   return value as TeamName;
 };


### PR DESCRIPTION
- fundamental パッケージに汎用的な assertRegex 関数を追加
- TeamName ファクトリ関数で /^[a-z]+$/ パターンによるバリデーションを実装
- 大文字、数字、記号が拒否されることを確認するテストを追加