### PR TITLE
feat(team): 参加者の在籍ステータスとチーム所属の整合性チェック

### DIFF
--- a/apps/web/src/handlers/team-membership.handler.ts
+++ b/apps/web/src/handlers/team-membership.handler.ts
@@ -1,0 +1,87 @@
+import type { HandlerRegistry } from "@ponp/event-bus";
+import { registerHandler } from "@ponp/event-bus";
+import {
+  type ParticipantReactivatedEvent,
+  ParticipantReactivatedEvent as ParticipantReactivatedEventConstructor,
+  type ParticipantSuspendedEvent,
+  ParticipantSuspendedEvent as ParticipantSuspendedEventConstructor,
+  type ParticipantWithdrawnEvent,
+  ParticipantWithdrawnEvent as ParticipantWithdrawnEventConstructor,
+} from "@ponp/integration-events";
+import type { ExecuteHandleMemberJoinUseCase } from "@ponp/team";
+import type { ExecuteHandleMemberLeaveUseCase } from "@ponp/team";
+
+/**
+ * チームメンバーシップイベントハンドラの依存関係です。
+ */
+type Dependencies = {
+  /**
+   * メンバー離脱処理ユースケースです。
+   */
+  handleMemberLeave: ExecuteHandleMemberLeaveUseCase;
+
+  /**
+   * メンバー参加処理ユースケースです。
+   */
+  handleMemberJoin: ExecuteHandleMemberJoinUseCase;
+};
+
+/**
+ * チームメンバーシップのイベントハンドラを登録します。
+ *
+ * @param registry ハンドラレジストリです。
+ * @param dependencies 依存関係です。
+ */
+export const registerTeamMembershipHandlers = (
+  registry: HandlerRegistry,
+  dependencies: Dependencies,
+): void => {
+  const { handleMemberLeave, handleMemberJoin } = dependencies;
+
+  /**
+   * 参加者休会イベントのハンドラです。
+   * 参加者が休会した際にチームの整合性をチェックし、必要に応じて再編成を行います。
+   */
+  registerHandler(
+    registry,
+    ParticipantSuspendedEventConstructor,
+    "team-membership-on-suspended",
+    async (event: ParticipantSuspendedEvent) => {
+      await handleMemberLeave({
+        leavingParticipantName: event.payload.name,
+        teamId: event.payload.previousTeamId,
+      });
+    },
+  );
+
+  /**
+   * 参加者退会イベントのハンドラです。
+   * 参加者が退会した際にチームの整合性をチェックし、必要に応じて再編成を行います。
+   */
+  registerHandler(
+    registry,
+    ParticipantWithdrawnEventConstructor,
+    "team-membership-on-withdrawn",
+    async (event: ParticipantWithdrawnEvent) => {
+      await handleMemberLeave({
+        leavingParticipantName: event.payload.name,
+        teamId: event.payload.previousTeamId,
+      });
+    },
+  );
+
+  /**
+   * 参加者復帰イベントのハンドラです。
+   * 参加者が復帰した際に最小人数のチームに割り当て、必要に応じてチームを分割します。
+   */
+  registerHandler(
+    registry,
+    ParticipantReactivatedEventConstructor,
+    "team-membership-on-reactivated",
+    async (event: ParticipantReactivatedEvent) => {
+      await handleMemberJoin({
+        participantId: event.payload.participantId,
+      });
+    },
+  );
+};

--- a/packages/integration-events/src/participant.ts
+++ b/packages/integration-events/src/participant.ts
@@ -16,6 +16,7 @@ export const ParticipantEnrolledSchema = z.object({
 export const ParticipantSuspendedSchema = z.object({
   participantId: z.string().uuid(),
   name: z.string().min(1),
+  previousTeamId: z.string().uuid(),
   suspendedAt: z.coerce.date(),
 });
 
@@ -34,7 +35,18 @@ export const ParticipantReactivatedSchema = z.object({
 export const ParticipantWithdrawnSchema = z.object({
   participantId: z.string().uuid(),
   name: z.string().min(1),
+  previousTeamId: z.string().uuid(),
   withdrawnAt: z.coerce.date(),
+});
+
+/**
+ * 参加者のチーム割り当てイベントのペイロードスキーマです。
+ */
+export const ParticipantTeamAssignedSchema = z.object({
+  participantId: z.string().uuid(),
+  name: z.string().min(1),
+  teamId: z.string().uuid(),
+  assignedAt: z.coerce.date(),
 });
 
 /**
@@ -70,6 +82,14 @@ export const ParticipantWithdrawnEvent = createEventConstructor(
 );
 
 /**
+ * 参加者のチーム割り当てイベントのコンストラクタです。
+ */
+export const ParticipantTeamAssignedEvent = createEventConstructor(
+  "PARTICIPANT_TEAM_ASSIGNED",
+  ParticipantTeamAssignedSchema,
+);
+
+/**
  * 参加者の入会イベントのペイロード型です。
  */
 export type ParticipantEnrolledPayload = z.infer<typeof ParticipantEnrolledSchema>;
@@ -85,6 +105,10 @@ export type ParticipantReactivatedPayload = z.infer<typeof ParticipantReactivate
  * 参加者の退会イベントのペイロード型です。
  */
 export type ParticipantWithdrawnPayload = z.infer<typeof ParticipantWithdrawnSchema>;
+/**
+ * 参加者のチーム割り当てイベントのペイロード型です。
+ */
+export type ParticipantTeamAssignedPayload = z.infer<typeof ParticipantTeamAssignedSchema>;
 
 /**
  * 参加者の入会イベントの型です。
@@ -102,6 +126,10 @@ export type ParticipantReactivatedEvent = ReturnType<typeof ParticipantReactivat
  * 参加者の退会イベントの型です。
  */
 export type ParticipantWithdrawnEvent = ReturnType<typeof ParticipantWithdrawnEvent>;
+/**
+ * 参加者のチーム割り当てイベントの型です。
+ */
+export type ParticipantTeamAssignedEvent = ReturnType<typeof ParticipantTeamAssignedEvent>;
 
 /**
  * 参加者コンテキストの統合イベントのユニオン型です。
@@ -110,4 +138,5 @@ export type ParticipantIntegrationEvent =
   | ParticipantEnrolledEvent
   | ParticipantSuspendedEvent
   | ParticipantReactivatedEvent
-  | ParticipantWithdrawnEvent;
+  | ParticipantWithdrawnEvent
+  | ParticipantTeamAssignedEvent;

--- a/packages/participant/src/application/index.ts
+++ b/packages/participant/src/application/index.ts
@@ -2,3 +2,4 @@ export * from "./use-case/enroll.use-case";
 export * from "./use-case/suspend.use-case";
 export * from "./use-case/reactivate.use-case";
 export * from "./use-case/withdraw.use-case";
+export * from "./use-case/assign-team.use-case";

--- a/packages/participant/src/application/use-case/assign-team.use-case.ts
+++ b/packages/participant/src/application/use-case/assign-team.use-case.ts
@@ -1,0 +1,80 @@
+import { DomainError } from "@ponp/fundamental";
+
+import { Participant, ParticipantId, TeamId } from "../../domain";
+import type { EventPublisher } from "../port/event-publisher";
+import type { ParticipantRepository } from "../port/participant.repository";
+
+/**
+ * 参加者のチーム割り当てユースケースが必要とする依存関係です。
+ */
+type Dependencies = {
+  /**
+   * 参加者を保存・取得するリポジトリの関数です。
+   * @see ParticipantRepository
+   */
+  participantRepository: ParticipantRepository;
+
+  /**
+   * 参加者イベントを発行するパブリッシャーです。
+   * @see EventPublisher
+   */
+  eventPublisher: EventPublisher;
+};
+
+/**
+ * 参加者のチーム割り当てに必要なパラメータです。
+ */
+type AssignTeamParams = {
+  /**
+   * チームに割り当てる参加者の ID です。
+   */
+  participantId: string;
+
+  /**
+   * 割り当てるチームの ID です。
+   */
+  teamId: string;
+};
+
+/**
+ * 参加者のチーム割り当てユースケースの関数の型です。
+ */
+export type ExecuteAssignTeamUseCase = (params: AssignTeamParams) => Promise<void>;
+
+/**
+ * 参加者のチーム割り当てユースケースを作成します。
+ *
+ * @param dependencies 依存関係を指定します。
+ * @returns 参加者のチーム割り当てユースケースを返します。
+ */
+export const createAssignTeamUseCase = (dependencies: Dependencies): ExecuteAssignTeamUseCase => {
+  const { participantRepository, eventPublisher } = dependencies;
+
+  /**
+   * 参加者のチーム割り当てを扱うユースケースです。
+   *
+   * @param params 参加者のチーム割り当てに必要なパラメータです。
+   * @throws {ValidationError} 指定されたパラメータのいずれかが不正な場合にスローされます。
+   * @throws {DomainError} 参加者が存在しない場合やチーム割り当てできない状態の場合にスローされます。
+   * @throws {InfrastructureError} 参加者の取得・保存またはイベント発行に失敗した場合にスローされます。
+   */
+  const executeAssignTeamUseCase = async (params: AssignTeamParams) => {
+    const id = ParticipantId(params.participantId);
+    const teamId = TeamId(params.teamId);
+    const participant = await participantRepository.findById(id);
+
+    if (!participant) {
+      throw new DomainError("指定した参加者が存在しません。", { code: "PARTICIPANT_NOT_FOUND" });
+    }
+
+    const [assignedParticipant, participantTeamAssigned] = Participant.assignTeam(
+      participant,
+      teamId,
+    );
+
+    await participantRepository.save(assignedParticipant);
+    await eventPublisher.publish(participantTeamAssigned);
+  };
+
+  return executeAssignTeamUseCase;
+};

--- a/packages/participant/src/infrastructure/adapter/ponp-event-bus.event-publisher.ts
+++ b/packages/participant/src/infrastructure/adapter/ponp-event-bus.event-publisher.ts
@@ -5,6 +5,7 @@ import {
   ParticipantEnrolledEvent,
   ParticipantReactivatedEvent,
   ParticipantSuspendedEvent,
+  ParticipantTeamAssignedEvent,
   ParticipantWithdrawnEvent,
 } from "@ponp/integration-events";
 
@@ -14,6 +15,7 @@ import type {
   ParticipantEvent,
   ParticipantReactivated,
   ParticipantSuspended,
+  ParticipantTeamAssigned,
   ParticipantWithdrawn,
 } from "../../domain";
 import { ParticipantEventType } from "../../domain";
@@ -25,7 +27,8 @@ type IntegrationEvent =
   | ParticipantEnrolledEvent
   | ParticipantSuspendedEvent
   | ParticipantReactivatedEvent
-  | ParticipantWithdrawnEvent;
+  | ParticipantWithdrawnEvent
+  | ParticipantTeamAssignedEvent;
 
 /**
  * ドメインイベントを統合イベントに変換する関数のマップです。
@@ -45,6 +48,7 @@ const converters: {
     ParticipantSuspendedEvent({
       participantId: event.participantId,
       name: event.name,
+      previousTeamId: event.previousTeamId,
       suspendedAt: event.suspendedAt,
     }),
   [ParticipantEventType.REACTIVATED]: (event: ParticipantReactivated) =>
@@ -57,7 +61,15 @@ const converters: {
     ParticipantWithdrawnEvent({
       participantId: event.participantId,
       name: event.name,
+      previousTeamId: event.previousTeamId,
       withdrawnAt: event.withdrawnAt,
+    }),
+  [ParticipantEventType.TEAM_ASSIGNED]: (event: ParticipantTeamAssigned) =>
+    ParticipantTeamAssignedEvent({
+      participantId: event.participantId,
+      name: event.name,
+      teamId: event.teamId,
+      assignedAt: event.assignedAt,
     }),
 };
 

--- a/packages/team/package.json
+++ b/packages/team/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ponp/fundamental": "workspace:*"
+    "@ponp/fundamental": "workspace:*",
+    "drizzle-orm": "^0.45.1"
   },
   "devDependencies": {
     "@ponp/eslint-config": "workspace:*",

--- a/packages/team/src/application/index.ts
+++ b/packages/team/src/application/index.ts
@@ -1,0 +1,2 @@
+export * from "./port";
+export * from "./use-case";

--- a/packages/team/src/application/port/admin-notifier.ts
+++ b/packages/team/src/application/port/admin-notifier.ts
@@ -1,0 +1,62 @@
+import type { TeamId } from "../../domain";
+
+/**
+ * チーム人数不足の通知に必要なパラメータです。
+ */
+export type NotifyTeamUnderMinimumParams = {
+  /**
+   * 減少した参加者の名前です。
+   */
+  leavingParticipantName: string;
+
+  /**
+   * 人数不足になったチームの識別子です。
+   */
+  teamId: TeamId;
+
+  /**
+   * 現在のメンバー数です。
+   */
+  currentMemberCount: number;
+
+  /**
+   * 残っている参加者名のリストです。
+   */
+  remainingParticipantNames: string[];
+};
+
+/**
+ * 合流先がない通知に必要なパラメータです。
+ */
+export type NotifyNoMergeTargetParams = {
+  /**
+   * 減少した参加者の名前です。
+   */
+  leavingParticipantName: string;
+
+  /**
+   * 合流先を探している参加者の名前です。
+   */
+  soleParticipantName: string;
+};
+
+/**
+ * 管理者への通知を行うポートのインターフェースです。
+ */
+export type AdminNotifier = {
+  /**
+   * チーム人数が最小人数を下回った際に管理者に通知します。
+   *
+   * @param params 通知に必要なパラメータです。
+   * @throws {InfrastructureError} 通知に失敗した場合にスローされます。
+   */
+  notifyTeamUnderMinimum: (params: NotifyTeamUnderMinimumParams) => Promise<void>;
+
+  /**
+   * 合流先がない場合に管理者に通知します。
+   *
+   * @param params 通知に必要なパラメータです。
+   * @throws {InfrastructureError} 通知に失敗した場合にスローされます。
+   */
+  notifyNoMergeTarget: (params: NotifyNoMergeTargetParams) => Promise<void>;
+};

--- a/packages/team/src/application/port/index.ts
+++ b/packages/team/src/application/port/index.ts
@@ -1,0 +1,4 @@
+export * from "./team.repository";
+export * from "./team-member-count.query";
+export * from "./admin-notifier";
+export * from "./participant-assignment";

--- a/packages/team/src/application/port/participant-assignment.ts
+++ b/packages/team/src/application/port/participant-assignment.ts
@@ -1,0 +1,28 @@
+/**
+ * 参加者のチーム割り当てパラメータです。
+ */
+export type AssignParticipantToTeamParams = {
+  /**
+   * 参加者の識別子です。
+   */
+  participantId: string;
+
+  /**
+   * 割り当てるチームの識別子です。
+   */
+  teamId: string;
+};
+
+/**
+ * 参加者のチーム割り当てを行うポートのインターフェースです。
+ */
+export type ParticipantAssignment = {
+  /**
+   * 参加者をチームに割り当てます。
+   *
+   * @param params 割り当てに必要なパラメータです。
+   * @throws {DomainError} 参加者が存在しない場合や割り当てできない状態の場合にスローされます。
+   * @throws {InfrastructureError} 割り当てに失敗した場合にスローされます。
+   */
+  assignToTeam: (params: AssignParticipantToTeamParams) => Promise<void>;
+};

--- a/packages/team/src/application/port/team-member-count.query.ts
+++ b/packages/team/src/application/port/team-member-count.query.ts
@@ -1,0 +1,62 @@
+import type { TeamId } from "../../domain";
+
+/**
+ * チームとそのメンバー数を表す型です。
+ */
+export type TeamMemberCount = {
+  /**
+   * チームの識別子です。
+   */
+  teamId: TeamId;
+
+  /**
+   * チームのメンバー数です。
+   */
+  count: number;
+};
+
+/**
+ * チームメンバーの情報を表す型です。
+ */
+export type TeamMember = {
+  /**
+   * 参加者の識別子です。
+   */
+  participantId: string;
+
+  /**
+   * 参加者の名前です。
+   */
+  name: string;
+};
+
+/**
+ * チームメンバー数を取得するためのクエリのインターフェースです。
+ */
+export type TeamMemberCountQuery = {
+  /**
+   * 全チームのメンバー数を取得します。
+   *
+   * @returns 全チームのメンバー数のリストを返します。
+   * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+   */
+  getAllTeamMemberCounts: () => Promise<TeamMemberCount[]>;
+
+  /**
+   * 指定したチームのメンバー数を取得します。
+   *
+   * @param teamId 取得するチームの識別子です。
+   * @returns チームのメンバー数を返します。
+   * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+   */
+  getTeamMemberCount: (teamId: TeamId) => Promise<number>;
+
+  /**
+   * 指定したチームのメンバー一覧を取得します。
+   *
+   * @param teamId 取得するチームの識別子です。
+   * @returns チームメンバーのリストを返します。
+   * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+   */
+  getTeamMembers: (teamId: TeamId) => Promise<TeamMember[]>;
+};

--- a/packages/team/src/application/port/team.repository.ts
+++ b/packages/team/src/application/port/team.repository.ts
@@ -1,0 +1,31 @@
+import type { Team, TeamId } from "../../domain";
+
+/**
+ * チームリポジトリのインターフェースです。
+ */
+export type TeamRepository = {
+  /**
+   * チームを保存します。
+   *
+   * @param team 保存するチームです。
+   * @throws {InfrastructureError} 保存に失敗した場合はエラーをスローします。
+   */
+  save: (team: Team) => Promise<void>;
+
+  /**
+   * ID からチームを取得します。
+   *
+   * @param id 検索するチームの ID です。
+   * @returns 見つかった場合はチームを、存在しない場合は undefined を返します。
+   * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+   */
+  findById: (id: TeamId) => Promise<Team | undefined>;
+
+  /**
+   * すべてのチームを取得します。
+   *
+   * @returns 全チームのリストを返します。
+   * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+   */
+  findAll: () => Promise<Team[]>;
+};

--- a/packages/team/src/application/use-case/handle-member-join.use-case.test.ts
+++ b/packages/team/src/application/use-case/handle-member-join.use-case.test.ts
@@ -1,0 +1,127 @@
+import { DomainError } from "@ponp/fundamental";
+import { describe, expect, test, vi } from "vitest";
+
+import { TeamId } from "../../domain";
+import type { ParticipantAssignment } from "../port/participant-assignment";
+import type { TeamMemberCountQuery } from "../port/team-member-count.query";
+import { createHandleMemberJoinUseCase } from "./handle-member-join.use-case";
+
+describe("createHandleMemberJoinUseCase", () => {
+  /**
+   * テスト用のチームIDです。
+   */
+  const TEST_TEAM_ID = "a1b2c3d4-e5f6-4a7b-ac9d-0e1f2a3b4c5d";
+
+  /**
+   * テスト用の参加者IDです。
+   */
+  const TEST_PARTICIPANT_ID = "b2c3d4e5-f6a7-4b8c-ad0e-1f2a3b4c5d6e";
+
+  /**
+   * テスト用のモック依存関係を作成します。
+   */
+  const createMockDependencies = () => {
+    const teamMemberCountQuery: TeamMemberCountQuery = {
+      getTeamMemberCount: vi.fn(),
+      getTeamMembers: vi.fn(),
+      getAllTeamMemberCounts: vi.fn(),
+    };
+
+    const participantAssignment: ParticipantAssignment = {
+      assignToTeam: vi.fn(),
+    };
+
+    const splitTeam = vi.fn();
+
+    return { teamMemberCountQuery, participantAssignment, splitTeam };
+  };
+
+  test("最小人数のチームに参加者を割り当てる", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 2 },
+      { teamId: TeamId("c3d4e5f6-a7b8-4c9d-ae1f-2a3b4c5d6e7f"), count: 3 },
+    ]);
+
+    const useCase = createHandleMemberJoinUseCase(deps);
+    const result = await useCase({ participantId: TEST_PARTICIPANT_ID });
+
+    expect(result).toEqual({
+      assignedTeamId: TeamId(TEST_TEAM_ID),
+      teamWasSplit: false,
+    });
+    expect(deps.participantAssignment.assignToTeam).toHaveBeenCalledWith({
+      participantId: TEST_PARTICIPANT_ID,
+      teamId: TeamId(TEST_TEAM_ID),
+    });
+    expect(deps.splitTeam).not.toHaveBeenCalled();
+  });
+
+  test("4名のチームには割り当てできない（最大人数なので選択対象外）", async () => {
+    const deps = createMockDependencies();
+    // 4名のチームしかない場合は割り当て不可
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 4 },
+    ]);
+
+    const useCase = createHandleMemberJoinUseCase(deps);
+
+    await expect(useCase({ participantId: TEST_PARTICIPANT_ID })).rejects.toThrow(DomainError);
+  });
+
+  test("3名のチームに割り当てると4名になるが分割は不要", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 3 }, // 割り当て後4名
+    ]);
+
+    const useCase = createHandleMemberJoinUseCase(deps);
+    const result = await useCase({ participantId: TEST_PARTICIPANT_ID });
+
+    expect(result).toEqual({
+      assignedTeamId: TeamId(TEST_TEAM_ID),
+      teamWasSplit: false,
+    });
+    expect(deps.splitTeam).not.toHaveBeenCalled();
+  });
+
+  test("割り当て可能なチームが存在しない場合はエラーをスローする", async () => {
+    const deps = createMockDependencies();
+    // 全てのチームが4名以上
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 4 },
+      { teamId: TeamId("c3d4e5f6-a7b8-4c9d-ae1f-2a3b4c5d6e7f"), count: 4 },
+    ]);
+
+    const useCase = createHandleMemberJoinUseCase(deps);
+
+    await expect(useCase({ participantId: TEST_PARTICIPANT_ID })).rejects.toThrow(DomainError);
+    await expect(useCase({ participantId: TEST_PARTICIPANT_ID })).rejects.toThrow(
+      "割り当て可能なチームが存在しません",
+    );
+  });
+
+  test("チームが空の配列の場合はエラーをスローする", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([]);
+
+    const useCase = createHandleMemberJoinUseCase(deps);
+
+    await expect(useCase({ participantId: TEST_PARTICIPANT_ID })).rejects.toThrow(DomainError);
+  });
+
+  test("同じ人数のチームがある場合でも最小人数チームに割り当てる", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 2 },
+      { teamId: TeamId("c3d4e5f6-a7b8-4c9d-ae1f-2a3b4c5d6e7f"), count: 2 },
+    ]);
+
+    const useCase = createHandleMemberJoinUseCase(deps);
+    const result = await useCase({ participantId: TEST_PARTICIPANT_ID });
+
+    // いずれかのチームに割り当てられる
+    expect(result.assignedTeamId).toBeDefined();
+    expect(deps.participantAssignment.assignToTeam).toHaveBeenCalled();
+  });
+});

--- a/packages/team/src/application/use-case/handle-member-join.use-case.ts
+++ b/packages/team/src/application/use-case/handle-member-join.use-case.ts
@@ -1,0 +1,125 @@
+import { DomainError } from "@ponp/fundamental";
+
+import { selectTeamWithMinMembers, type TeamId } from "../../domain";
+import type { ParticipantAssignment } from "../port/participant-assignment";
+import type { TeamMemberCountQuery } from "../port/team-member-count.query";
+
+/**
+ * メンバー参加処理ユースケースが必要とする依存関係です。
+ */
+type Dependencies = {
+  /**
+   * チームメンバー数を取得するクエリです。
+   */
+  teamMemberCountQuery: TeamMemberCountQuery;
+
+  /**
+   * 参加者のチーム割り当てを行うポートです。
+   */
+  participantAssignment: ParticipantAssignment;
+
+  /**
+   * チーム分割を行う関数です。
+   */
+  splitTeam: ExecuteSplitTeamUseCase;
+};
+
+/**
+ * チーム分割ユースケースの関数の型です（循環参照回避用）。
+ */
+type ExecuteSplitTeamUseCase = (params: { teamId: string }) => Promise<void>;
+
+/**
+ * メンバー参加処理に必要なパラメータです。
+ */
+type HandleMemberJoinParams = {
+  /**
+   * 復帰した参加者の識別子です。
+   */
+  participantId: string;
+};
+
+/**
+ * メンバー参加処理ユースケースの結果です。
+ */
+export type HandleMemberJoinResult = {
+  /**
+   * 割り当てられたチームの識別子です。
+   */
+  assignedTeamId: TeamId;
+
+  /**
+   * チームが分割されたかどうかです。
+   */
+  teamWasSplit: boolean;
+};
+
+/**
+ * メンバー参加処理ユースケースの関数の型です。
+ */
+export type ExecuteHandleMemberJoinUseCase = (
+  params: HandleMemberJoinParams,
+) => Promise<HandleMemberJoinResult>;
+
+/**
+ * メンバー参加処理ユースケースを作成します。
+ *
+ * @param dependencies 依存関係を指定します。
+ * @returns メンバー参加処理ユースケースを返します。
+ */
+export const createHandleMemberJoinUseCase = (
+  dependencies: Dependencies,
+): ExecuteHandleMemberJoinUseCase => {
+  const { teamMemberCountQuery, participantAssignment, splitTeam } = dependencies;
+
+  /**
+   * 復帰した参加者を最小人数のチームに割り当て、必要に応じてチームを分割します。
+   *
+   * @param params メンバー参加処理に必要なパラメータです。
+   * @returns 割り当て結果を返します。
+   * @throws {DomainError} 割り当て可能なチームが存在しない場合にスローされます。
+   * @throws {InfrastructureError} 処理に失敗した場合にスローされます。
+   */
+  const executeHandleMemberJoinUseCase = async (
+    params: HandleMemberJoinParams,
+  ): Promise<HandleMemberJoinResult> => {
+    // 全チームのメンバー数を取得
+    const allTeamCounts = await teamMemberCountQuery.getAllTeamMemberCounts();
+
+    // 最小人数のチームを選択
+    const targetTeam = selectTeamWithMinMembers(
+      allTeamCounts.map((t) => ({ teamId: t.teamId, memberCount: t.count })),
+    );
+
+    if (!targetTeam) {
+      throw new DomainError("割り当て可能なチームが存在しません。", {
+        code: "NO_AVAILABLE_TEAM",
+      });
+    }
+
+    // 参加者をチームに割り当て
+    await participantAssignment.assignToTeam({
+      participantId: params.participantId,
+      teamId: targetTeam.teamId,
+    });
+
+    // 割り当て後のメンバー数を計算（+1）
+    const newMemberCount = targetTeam.memberCount + 1;
+
+    // 5名以上になった場合はチームを分割
+    if (newMemberCount >= 5) {
+      await splitTeam({ teamId: targetTeam.teamId });
+      return {
+        assignedTeamId: targetTeam.teamId,
+        teamWasSplit: true,
+      };
+    }
+
+    return {
+      assignedTeamId: targetTeam.teamId,
+      teamWasSplit: false,
+    };
+  };
+
+  return executeHandleMemberJoinUseCase;
+};

--- a/packages/team/src/application/use-case/handle-member-leave.use-case.test.ts
+++ b/packages/team/src/application/use-case/handle-member-leave.use-case.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, test, vi } from "vitest";
+
+import { TeamId } from "../../domain";
+import type { AdminNotifier } from "../port/admin-notifier";
+import type { ParticipantAssignment } from "../port/participant-assignment";
+import type { TeamMemberCountQuery } from "../port/team-member-count.query";
+import { createHandleMemberLeaveUseCase } from "./handle-member-leave.use-case";
+
+describe("createHandleMemberLeaveUseCase", () => {
+  /**
+   * テスト用のチームIDです。
+   */
+  const TEST_TEAM_ID = "a1b2c3d4-e5f6-4a7b-ac9d-0e1f2a3b4c5d";
+
+  /**
+   * テスト用の合流先チームIDです。
+   */
+  const MERGE_TARGET_TEAM_ID = "b2c3d4e5-f6a7-4b8c-ad0e-1f2a3b4c5d6e";
+
+  /**
+   * テスト用のモック依存関係を作成します。
+   */
+  const createMockDependencies = () => {
+    const teamMemberCountQuery: TeamMemberCountQuery = {
+      getTeamMemberCount: vi.fn(),
+      getTeamMembers: vi.fn(),
+      getAllTeamMemberCounts: vi.fn(),
+    };
+
+    const adminNotifier: AdminNotifier = {
+      notifyTeamUnderMinimum: vi.fn(),
+      notifyNoMergeTarget: vi.fn(),
+    };
+
+    const participantAssignment: ParticipantAssignment = {
+      assignToTeam: vi.fn(),
+    };
+
+    return { teamMemberCountQuery, adminNotifier, participantAssignment };
+  };
+
+  test("離脱後のメンバーが2名以上の場合はOKを返す", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMemberCount).mockResolvedValue(3);
+
+    const useCase = createHandleMemberLeaveUseCase(deps);
+    const result = await useCase({
+      leavingParticipantName: "山田太郎",
+      teamId: TEST_TEAM_ID,
+    });
+
+    expect(result).toEqual({ type: "OK" });
+    expect(deps.adminNotifier.notifyTeamUnderMinimum).not.toHaveBeenCalled();
+  });
+
+  test("離脱後のメンバーが2名の場合はOKを返す（最低人数なので正常）", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMemberCount).mockResolvedValue(2);
+
+    const useCase = createHandleMemberLeaveUseCase(deps);
+    const result = await useCase({
+      leavingParticipantName: "山田太郎",
+      teamId: TEST_TEAM_ID,
+    });
+
+    expect(result).toEqual({ type: "OK" });
+    expect(deps.adminNotifier.notifyTeamUnderMinimum).not.toHaveBeenCalled();
+  });
+
+  test("離脱後のメンバーが1名の場合は自動合流処理を行いTEAM_NEEDS_MERGEを返す", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMemberCount).mockResolvedValue(1);
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue([
+      { participantId: "p1", name: "鈴木花子" },
+    ]);
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 1 },
+      { teamId: TeamId(MERGE_TARGET_TEAM_ID), count: 2 },
+    ]);
+
+    const useCase = createHandleMemberLeaveUseCase(deps);
+    const result = await useCase({
+      leavingParticipantName: "山田太郎",
+      teamId: TEST_TEAM_ID,
+    });
+
+    expect(result).toEqual({
+      type: "TEAM_NEEDS_MERGE",
+      teamId: TeamId(TEST_TEAM_ID),
+      soleParticipant: {
+        id: "p1",
+        name: "鈴木花子",
+      },
+    });
+    expect(deps.participantAssignment.assignToTeam).toHaveBeenCalledWith({
+      participantId: "p1",
+      teamId: TeamId(MERGE_TARGET_TEAM_ID),
+    });
+  });
+
+  test("離脱後のメンバーが1名で合流先がない場合は管理者に通知してNO_MERGE_TARGETを返す", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMemberCount).mockResolvedValue(1);
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue([
+      { participantId: "p1", name: "鈴木花子" },
+    ]);
+    // 全てのチームが4名以上（合流不可）
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 1 },
+      { teamId: TeamId(MERGE_TARGET_TEAM_ID), count: 4 },
+    ]);
+
+    const useCase = createHandleMemberLeaveUseCase(deps);
+    const result = await useCase({
+      leavingParticipantName: "山田太郎",
+      teamId: TEST_TEAM_ID,
+    });
+
+    expect(result).toEqual({
+      type: "NO_MERGE_TARGET",
+      soleParticipant: {
+        id: "p1",
+        name: "鈴木花子",
+      },
+    });
+    expect(deps.adminNotifier.notifyNoMergeTarget).toHaveBeenCalledWith({
+      leavingParticipantName: "山田太郎",
+      soleParticipantName: "鈴木花子",
+    });
+    expect(deps.participantAssignment.assignToTeam).not.toHaveBeenCalled();
+  });
+
+  test("離脱後のメンバーが0名の場合はOKを返す", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMemberCount).mockResolvedValue(0);
+
+    const useCase = createHandleMemberLeaveUseCase(deps);
+    const result = await useCase({
+      leavingParticipantName: "山田太郎",
+      teamId: TEST_TEAM_ID,
+    });
+
+    expect(result).toEqual({ type: "OK" });
+  });
+
+  test("合流先の選択では自身のチームを除外する", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMemberCount).mockResolvedValue(1);
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue([
+      { participantId: "p1", name: "鈴木花子" },
+    ]);
+    // 自身のチームと合流先候補
+    vi.mocked(deps.teamMemberCountQuery.getAllTeamMemberCounts).mockResolvedValue([
+      { teamId: TeamId(TEST_TEAM_ID), count: 1 }, // 自身のチーム
+      { teamId: TeamId(MERGE_TARGET_TEAM_ID), count: 3 }, // 合流先
+    ]);
+
+    const useCase = createHandleMemberLeaveUseCase(deps);
+    await useCase({
+      leavingParticipantName: "山田太郎",
+      teamId: TEST_TEAM_ID,
+    });
+
+    // 合流先は自身のチーム以外の最小人数チーム
+    expect(deps.participantAssignment.assignToTeam).toHaveBeenCalledWith({
+      participantId: "p1",
+      teamId: TeamId(MERGE_TARGET_TEAM_ID),
+    });
+  });
+});

--- a/packages/team/src/application/use-case/handle-member-leave.use-case.ts
+++ b/packages/team/src/application/use-case/handle-member-leave.use-case.ts
@@ -1,0 +1,165 @@
+import {
+  selectTeamWithMinMembers,
+  type TeamConsistencyCheckResult,
+  TeamId,
+} from "../../domain";
+import type { AdminNotifier } from "../port/admin-notifier";
+import type { ParticipantAssignment } from "../port/participant-assignment";
+import type { TeamMemberCountQuery } from "../port/team-member-count.query";
+
+/**
+ * メンバー離脱処理ユースケースが必要とする依存関係です。
+ */
+type Dependencies = {
+  /**
+   * チームメンバー数を取得するクエリです。
+   */
+  teamMemberCountQuery: TeamMemberCountQuery;
+
+  /**
+   * 管理者への通知を行うポートです。
+   */
+  adminNotifier: AdminNotifier;
+
+  /**
+   * 参加者のチーム割り当てを行うポートです。
+   */
+  participantAssignment: ParticipantAssignment;
+};
+
+/**
+ * メンバー離脱処理に必要なパラメータです。
+ */
+type HandleMemberLeaveParams = {
+  /**
+   * 離脱した参加者の名前です。
+   */
+  leavingParticipantName: string;
+
+  /**
+   * 離脱した参加者が所属していたチームの識別子です。
+   */
+  teamId: string;
+};
+
+/**
+ * メンバー離脱処理ユースケースの結果です。
+ */
+export type HandleMemberLeaveResult = TeamConsistencyCheckResult;
+
+/**
+ * メンバー離脱処理ユースケースの関数の型です。
+ */
+export type ExecuteHandleMemberLeaveUseCase = (
+  params: HandleMemberLeaveParams,
+) => Promise<HandleMemberLeaveResult>;
+
+/**
+ * メンバー離脱処理ユースケースを作成します。
+ *
+ * @param dependencies 依存関係を指定します。
+ * @returns メンバー離脱処理ユースケースを返します。
+ */
+export const createHandleMemberLeaveUseCase = (
+  dependencies: Dependencies,
+): ExecuteHandleMemberLeaveUseCase => {
+  const { teamMemberCountQuery, adminNotifier, participantAssignment } = dependencies;
+
+  /**
+   * メンバー離脱後のチーム整合性をチェックし、必要な処理を行います。
+   *
+   * @param params メンバー離脱処理に必要なパラメータです。
+   * @returns チームの整合性チェック結果を返します。
+   * @throws {ValidationError} パラメータが不正な場合にスローされます。
+   * @throws {InfrastructureError} 処理に失敗した場合にスローされます。
+   */
+  const executeHandleMemberLeaveUseCase = async (
+    params: HandleMemberLeaveParams,
+  ): Promise<HandleMemberLeaveResult> => {
+    const teamId = TeamId(params.teamId);
+
+    // 離脱後のチームのメンバー数を取得
+    const memberCount = await teamMemberCountQuery.getTeamMemberCount(teamId);
+
+    // 2名以上の場合は正常
+    if (memberCount >= 2) {
+      return { type: "OK" };
+    }
+
+    // 残っているメンバーを取得
+    const remainingMembers = await teamMemberCountQuery.getTeamMembers(teamId);
+
+    // 2名以下だが1名より多い場合（つまり2名の場合のメンバー減少）は管理者に通知
+    if (memberCount === 2) {
+      await adminNotifier.notifyTeamUnderMinimum({
+        leavingParticipantName: params.leavingParticipantName,
+        teamId,
+        currentMemberCount: memberCount,
+        remainingParticipantNames: remainingMembers.map((m) => m.name),
+      });
+
+      return {
+        type: "TEAM_UNDER_MINIMUM",
+        teamId,
+        memberCount,
+        remainingMembers: remainingMembers.map((m) => ({
+          id: m.participantId,
+          name: m.name,
+        })),
+      };
+    }
+
+    // 1名の場合は自動合流処理
+    if (memberCount === 1) {
+      const soleParticipant = remainingMembers[0];
+      if (!soleParticipant) {
+        return { type: "OK" }; // メンバーが既にいない場合
+      }
+
+      // 合流先を探す
+      const allTeamCounts = await teamMemberCountQuery.getAllTeamMemberCounts();
+
+      // 現在のチームを除外した上で最小人数のチームを選択
+      const otherTeams = allTeamCounts.filter((t) => t.teamId !== teamId);
+      const targetTeam = selectTeamWithMinMembers(
+        otherTeams.map((t) => ({ teamId: t.teamId, memberCount: t.count })),
+      );
+
+      if (!targetTeam) {
+        // 合流先がない場合は管理者に通知
+        await adminNotifier.notifyNoMergeTarget({
+          leavingParticipantName: params.leavingParticipantName,
+          soleParticipantName: soleParticipant.name,
+        });
+
+        return {
+          type: "NO_MERGE_TARGET",
+          soleParticipant: {
+            id: soleParticipant.participantId,
+            name: soleParticipant.name,
+          },
+        };
+      }
+
+      // 合流処理を実行
+      await participantAssignment.assignToTeam({
+        participantId: soleParticipant.participantId,
+        teamId: targetTeam.teamId,
+      });
+
+      return {
+        type: "TEAM_NEEDS_MERGE",
+        teamId,
+        soleParticipant: {
+          id: soleParticipant.participantId,
+          name: soleParticipant.name,
+        },
+      };
+    }
+
+    // 0名の場合（チームが空になった）
+    return { type: "OK" };
+  };
+
+  return executeHandleMemberLeaveUseCase;
+};

--- a/packages/team/src/application/use-case/index.ts
+++ b/packages/team/src/application/use-case/index.ts
@@ -1,0 +1,3 @@
+export * from "./handle-member-leave.use-case";
+export * from "./handle-member-join.use-case";
+export * from "./split-team.use-case";

--- a/packages/team/src/application/use-case/split-team.use-case.test.ts
+++ b/packages/team/src/application/use-case/split-team.use-case.test.ts
@@ -1,0 +1,139 @@
+import { DomainError } from "@ponp/fundamental";
+import { describe, expect, test, vi } from "vitest";
+
+import { Team, TeamId, TeamName } from "../../domain";
+import type { ParticipantAssignment } from "../port/participant-assignment";
+import type { TeamMemberCountQuery } from "../port/team-member-count.query";
+import type { TeamRepository } from "../port/team.repository";
+import { createSplitTeamUseCase } from "./split-team.use-case";
+
+describe("createSplitTeamUseCase", () => {
+  /**
+   * テスト用のチームIDです。
+   */
+  const TEST_TEAM_ID = "a1b2c3d4-e5f6-4a7b-ac9d-0e1f2a3b4c5d";
+
+  /**
+   * テスト用の5人のメンバーです。
+   */
+  const TEST_MEMBERS = [
+    { participantId: "p1", name: "山田太郎" },
+    { participantId: "p2", name: "鈴木花子" },
+    { participantId: "p3", name: "佐藤次郎" },
+    { participantId: "p4", name: "田中三郎" },
+    { participantId: "p5", name: "高橋四郎" },
+  ];
+
+  /**
+   * テスト用のモック依存関係を作成します。
+   */
+  const createMockDependencies = () => {
+    const teamRepository: TeamRepository = {
+      save: vi.fn(),
+      findById: vi.fn(),
+      findAll: vi.fn(),
+    };
+
+    const teamMemberCountQuery: TeamMemberCountQuery = {
+      getTeamMemberCount: vi.fn(),
+      getTeamMembers: vi.fn(),
+      getAllTeamMemberCounts: vi.fn(),
+    };
+
+    const participantAssignment: ParticipantAssignment = {
+      assignToTeam: vi.fn(),
+    };
+
+    return { teamRepository, teamMemberCountQuery, participantAssignment };
+  };
+
+  test("5人のチームを3人と2人に分割する", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue(TEST_MEMBERS);
+    vi.mocked(deps.teamRepository.findAll).mockResolvedValue([
+      Team.reconstruct({ id: TEST_TEAM_ID, name: "a" }),
+    ]);
+
+    const useCase = createSplitTeamUseCase(deps);
+    await useCase({ teamId: TEST_TEAM_ID });
+
+    // 新しいチームが保存される
+    expect(deps.teamRepository.save).toHaveBeenCalledTimes(1);
+    const savedTeam = vi.mocked(deps.teamRepository.save).mock.calls[0]?.[0];
+    expect(savedTeam).toBeDefined();
+    expect(savedTeam?.name).toBe(TeamName("b")); // 次のアルファベット
+
+    // 2人が新しいチームに移動
+    expect(deps.participantAssignment.assignToTeam).toHaveBeenCalledTimes(2);
+  });
+
+  test("メンバーが5人未満の場合はエラーをスローする", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue([
+      { participantId: "p1", name: "山田太郎" },
+      { participantId: "p2", name: "鈴木花子" },
+      { participantId: "p3", name: "佐藤次郎" },
+      { participantId: "p4", name: "田中三郎" },
+    ]);
+
+    const useCase = createSplitTeamUseCase(deps);
+
+    await expect(useCase({ teamId: TEST_TEAM_ID })).rejects.toThrow(DomainError);
+    await expect(useCase({ teamId: TEST_TEAM_ID })).rejects.toThrow(
+      "チームのメンバー数が5名未満のため分割できません",
+    );
+  });
+
+  test("新しいチーム名は既存のチーム名の次のアルファベットになる", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue(TEST_MEMBERS);
+    vi.mocked(deps.teamRepository.findAll).mockResolvedValue([
+      Team.reconstruct({ id: TEST_TEAM_ID, name: "a" }),
+      Team.reconstruct({ id: "b2c3d4e5-f6a7-4b8c-ad0e-1f2a3b4c5d6e", name: "b" }),
+      Team.reconstruct({ id: "c3d4e5f6-a7b8-4c9d-ae1f-2a3b4c5d6e7f", name: "c" }),
+    ]);
+
+    const useCase = createSplitTeamUseCase(deps);
+    await useCase({ teamId: TEST_TEAM_ID });
+
+    const savedTeam = vi.mocked(deps.teamRepository.save).mock.calls[0]?.[0];
+    expect(savedTeam?.name).toBe(TeamName("d"));
+  });
+
+  test("チーム名に空きがある場合はその名前を使用する", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue(TEST_MEMBERS);
+    // "b"が欠けている
+    vi.mocked(deps.teamRepository.findAll).mockResolvedValue([
+      Team.reconstruct({ id: TEST_TEAM_ID, name: "a" }),
+      Team.reconstruct({ id: "c3d4e5f6-a7b8-4c9d-ae1f-2a3b4c5d6e7f", name: "c" }),
+    ]);
+
+    const useCase = createSplitTeamUseCase(deps);
+    await useCase({ teamId: TEST_TEAM_ID });
+
+    const savedTeam = vi.mocked(deps.teamRepository.save).mock.calls[0]?.[0];
+    expect(savedTeam?.name).toBe(TeamName("b"));
+  });
+
+  test("新しいチームに移動するメンバーは2人である", async () => {
+    const deps = createMockDependencies();
+    vi.mocked(deps.teamMemberCountQuery.getTeamMembers).mockResolvedValue(TEST_MEMBERS);
+    vi.mocked(deps.teamRepository.findAll).mockResolvedValue([
+      Team.reconstruct({ id: TEST_TEAM_ID, name: "a" }),
+    ]);
+
+    const useCase = createSplitTeamUseCase(deps);
+    await useCase({ teamId: TEST_TEAM_ID });
+
+    // 2人が新しいチームに割り当てられる
+    const assignCalls = vi.mocked(deps.participantAssignment.assignToTeam).mock.calls;
+    expect(assignCalls.length).toBe(2);
+
+    // 割り当てられた参加者IDはテストメンバーに含まれる
+    const assignedParticipantIds = assignCalls.map((call) => call[0]?.participantId);
+    for (const id of assignedParticipantIds) {
+      expect(TEST_MEMBERS.map((m) => m.participantId)).toContain(id);
+    }
+  });
+});

--- a/packages/team/src/application/use-case/split-team.use-case.ts
+++ b/packages/team/src/application/use-case/split-team.use-case.ts
@@ -1,0 +1,106 @@
+import { DomainError } from "@ponp/fundamental";
+
+import {
+  generateNextTeamName,
+  splitTeamMembers,
+  Team,
+  TeamId,
+  type TeamName,
+} from "../../domain";
+import type { ParticipantAssignment } from "../port/participant-assignment";
+import type { TeamMemberCountQuery } from "../port/team-member-count.query";
+import type { TeamRepository } from "../port/team.repository";
+
+/**
+ * チーム分割ユースケースが必要とする依存関係です。
+ */
+type Dependencies = {
+  /**
+   * チームリポジトリです。
+   */
+  teamRepository: TeamRepository;
+
+  /**
+   * チームメンバー数を取得するクエリです。
+   */
+  teamMemberCountQuery: TeamMemberCountQuery;
+
+  /**
+   * 参加者のチーム割り当てを行うポートです。
+   */
+  participantAssignment: ParticipantAssignment;
+};
+
+/**
+ * チーム分割に必要なパラメータです。
+ */
+type SplitTeamParams = {
+  /**
+   * 分割するチームの識別子です。
+   */
+  teamId: string;
+};
+
+/**
+ * チーム分割ユースケースの関数の型です。
+ */
+export type ExecuteSplitTeamUseCase = (params: SplitTeamParams) => Promise<void>;
+
+/**
+ * チーム分割ユースケースを作成します。
+ *
+ * @param dependencies 依存関係を指定します。
+ * @returns チーム分割ユースケースを返します。
+ */
+export const createSplitTeamUseCase = (dependencies: Dependencies): ExecuteSplitTeamUseCase => {
+  const { teamRepository, teamMemberCountQuery, participantAssignment } = dependencies;
+
+  /**
+   * チームを2つに分割します。
+   *
+   * @param params チーム分割に必要なパラメータです。
+   * @throws {DomainError} チームが存在しない場合にスローされます。
+   * @throws {InfrastructureError} 処理に失敗した場合にスローされます。
+   */
+  const executeSplitTeamUseCase = async (params: SplitTeamParams): Promise<void> => {
+    const teamId = TeamId(params.teamId);
+
+    // 分割対象のチームメンバーを取得
+    const members = await teamMemberCountQuery.getTeamMembers(teamId);
+
+    if (members.length < 5) {
+      throw new DomainError("チームのメンバー数が5名未満のため分割できません。", {
+        code: "TEAM_MEMBER_COUNT_TOO_LOW_TO_SPLIT",
+      });
+    }
+
+    // メンバーを2つに分割
+    const splitResult = splitTeamMembers(
+      members.map((m) => ({
+        participantId: m.participantId,
+        name: m.name,
+      })),
+    );
+
+    // 既存のチーム名を取得
+    const allTeams = await teamRepository.findAll();
+    const usedNames = allTeams.map((t) => t.name) as TeamName[];
+
+    // 新しいチーム名を生成
+    const newTeamName = generateNextTeamName(usedNames);
+
+    // 新しいチームを作成
+    const [newTeam] = Team.create({ name: newTeamName });
+    await teamRepository.save(newTeam);
+
+    // 新しいチームに移動するメンバーを割り当て
+    for (const member of splitResult.newTeamMembers) {
+      await participantAssignment.assignToTeam({
+        participantId: member.participantId,
+        teamId: newTeam.id,
+      });
+    }
+  };
+
+  return executeSplitTeamUseCase;
+};

--- a/packages/team/src/domain/index.ts
+++ b/packages/team/src/domain/index.ts
@@ -9,3 +9,25 @@ export type {
 
 export { TeamCreated, TeamEventType } from "./events";
 export type { TeamCreated as TeamCreatedType, TeamEvent } from "./events";
+
+export {
+  generateNextTeamName,
+  selectTeamWithMinMembers,
+  splitTeamMembers,
+} from "./team-assignment.service";
+export type {
+  TeamMemberInfo,
+  TeamSplitResult,
+  TeamWithMemberCount,
+} from "./team-assignment.service";
+
+export { isTeamConsistencyOK } from "./team-consistency";
+export type {
+  NoMergeTarget,
+  ParticipantInfo,
+  TeamConsistencyCheckResult,
+  TeamConsistencyOK,
+  TeamNeedsMerge,
+  TeamOverMaximum,
+  TeamUnderMinimum,
+} from "./team-consistency";

--- a/packages/team/src/domain/team-assignment.service.test.ts
+++ b/packages/team/src/domain/team-assignment.service.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+
+import { TeamId, TeamName } from "./team";
+import {
+  generateNextTeamName,
+  selectTeamWithMinMembers,
+  splitTeamMembers,
+  type TeamMemberInfo,
+  type TeamWithMemberCount,
+} from "./team-assignment.service";
+
+describe("selectTeamWithMinMembers", () => {
+  /**
+   * テスト用のチームID1です。
+   */
+  const TEST_TEAM_ID_1 = TeamId("a1b2c3d4-e5f6-4a7b-ac9d-0e1f2a3b4c5d");
+
+  /**
+   * テスト用のチームID2です。
+   */
+  const TEST_TEAM_ID_2 = TeamId("b2c3d4e5-f6a7-4b8c-ad0e-1f2a3b4c5d6e");
+
+  /**
+   * テスト用のチームID3です。
+   */
+  const TEST_TEAM_ID_3 = TeamId("c3d4e5f6-a7b8-4c9d-ae1f-2a3b4c5d6e7f");
+
+  test("最小人数のチームを選択する", () => {
+    const teams: TeamWithMemberCount[] = [
+      { teamId: TEST_TEAM_ID_1, memberCount: 3 },
+      { teamId: TEST_TEAM_ID_2, memberCount: 2 },
+      { teamId: TEST_TEAM_ID_3, memberCount: 4 },
+    ];
+
+    const result = selectTeamWithMinMembers(teams);
+
+    expect(result).toEqual({ teamId: TEST_TEAM_ID_2, memberCount: 2 });
+  });
+
+  test("4名以上のチームは選択対象から除外される", () => {
+    const teams: TeamWithMemberCount[] = [
+      { teamId: TEST_TEAM_ID_1, memberCount: 4 },
+      { teamId: TEST_TEAM_ID_2, memberCount: 4 },
+    ];
+
+    const result = selectTeamWithMinMembers(teams);
+
+    expect(result).toBeUndefined();
+  });
+
+  test("空のリストの場合は undefined を返す", () => {
+    const result = selectTeamWithMinMembers([]);
+
+    expect(result).toBeUndefined();
+  });
+
+  test("同じ人数のチームがある場合はいずれかが選択される", () => {
+    const teams: TeamWithMemberCount[] = [
+      { teamId: TEST_TEAM_ID_1, memberCount: 2 },
+      { teamId: TEST_TEAM_ID_2, memberCount: 2 },
+    ];
+
+    const result = selectTeamWithMinMembers(teams);
+
+    expect(result?.memberCount).toBe(2);
+    expect([TEST_TEAM_ID_1, TEST_TEAM_ID_2]).toContain(result?.teamId);
+  });
+});
+
+describe("splitTeamMembers", () => {
+  /**
+   * テスト用のメンバーリストです。
+   */
+  const TEST_MEMBERS: TeamMemberInfo[] = [
+    { participantId: "p1", name: "山田太郎" },
+    { participantId: "p2", name: "鈴木花子" },
+    { participantId: "p3", name: "佐藤次郎" },
+    { participantId: "p4", name: "田中三郎" },
+    { participantId: "p5", name: "高橋四郎" },
+  ];
+
+  test("5人のメンバーを3人と2人に分割する", () => {
+    const result = splitTeamMembers(TEST_MEMBERS);
+
+    expect(result.originalTeamMembers.length).toBe(3);
+    expect(result.newTeamMembers.length).toBe(2);
+  });
+
+  test("分割後のメンバーの合計は元のメンバー数と同じ", () => {
+    const result = splitTeamMembers(TEST_MEMBERS);
+
+    const allMembers = [...result.originalTeamMembers, ...result.newTeamMembers];
+    expect(allMembers.length).toBe(TEST_MEMBERS.length);
+  });
+
+  test("全てのメンバーが分割後に存在する", () => {
+    const result = splitTeamMembers(TEST_MEMBERS);
+
+    const allMemberIds = [
+      ...result.originalTeamMembers.map((m) => m.participantId),
+      ...result.newTeamMembers.map((m) => m.participantId),
+    ];
+
+    for (const member of TEST_MEMBERS) {
+      expect(allMemberIds).toContain(member.participantId);
+    }
+  });
+
+  test("4人のメンバーを2人と2人に分割する", () => {
+    const members = TEST_MEMBERS.slice(0, 4);
+    const result = splitTeamMembers(members);
+
+    expect(result.originalTeamMembers.length).toBe(2);
+    expect(result.newTeamMembers.length).toBe(2);
+  });
+});
+
+describe("generateNextTeamName", () => {
+  test("使用されていない最初の名前を生成する", () => {
+    const usedNames = [TeamName("a"), TeamName("b"), TeamName("c")];
+    const result = generateNextTeamName(usedNames);
+
+    expect(result).toBe("d");
+  });
+
+  test("名前が空の場合は'a'を生成する", () => {
+    const result = generateNextTeamName([]);
+
+    expect(result).toBe("a");
+  });
+
+  test("間に空きがある場合はその名前を生成する", () => {
+    const usedNames = [TeamName("a"), TeamName("c"), TeamName("d")];
+    const result = generateNextTeamName(usedNames);
+
+    expect(result).toBe("b");
+  });
+
+  test("全ての文字が使用されている場合はエラーをスローする", () => {
+    const alphabet = "abcdefghijklmnopqrstuvwxyz";
+    const usedNames = alphabet.split("").map((letter) => TeamName(letter));
+
+    expect(() => generateNextTeamName(usedNames)).toThrow("利用可能なチーム名がありません。");
+  });
+});

--- a/packages/team/src/domain/team-assignment.service.ts
+++ b/packages/team/src/domain/team-assignment.service.ts
@@ -1,0 +1,118 @@
+import type { TeamId, TeamName } from "./team";
+import { TeamName as TeamNameFactory } from "./team";
+
+/**
+ * チームとそのメンバー数を表す型です。
+ */
+export type TeamWithMemberCount = {
+  /**
+   * チームの識別子です。
+   */
+  teamId: TeamId;
+
+  /**
+   * チームのメンバー数です。
+   */
+  memberCount: number;
+};
+
+/**
+ * 最小人数のチームを選択します。
+ *
+ * @param teams チームとそのメンバー数のリストです。
+ * @returns 最小人数のチームを返します。同数の場合はランダムに選択します。存在しない場合は undefined を返します。
+ * @remarks 最大人数が4名以上のチームは選択対象から除外されます。
+ */
+export const selectTeamWithMinMembers = (
+  teams: TeamWithMemberCount[],
+): TeamWithMemberCount | undefined => {
+  // 最大人数（4名）以上のチームは除外する
+  const eligibleTeams = teams.filter((team) => team.memberCount < 4);
+
+  if (eligibleTeams.length === 0) {
+    return undefined;
+  }
+
+  // 最小人数を見つける
+  const minMemberCount = Math.min(...eligibleTeams.map((team) => team.memberCount));
+
+  // 最小人数のチームをすべて取得
+  const teamsWithMinMembers = eligibleTeams.filter((team) => team.memberCount === minMemberCount);
+
+  // ランダムに1つ選択
+  const randomIndex = Math.floor(Math.random() * teamsWithMinMembers.length);
+  return teamsWithMinMembers[randomIndex];
+};
+
+/**
+ * チームメンバーを表す型です。
+ */
+export type TeamMemberInfo = {
+  /**
+   * 参加者の識別子です。
+   */
+  participantId: string;
+
+  /**
+   * 参加者の名前です。
+   */
+  name: string;
+};
+
+/**
+ * チーム分割の結果を表す型です。
+ */
+export type TeamSplitResult = {
+  /**
+   * 元のチームに残るメンバーです。
+   */
+  originalTeamMembers: TeamMemberInfo[];
+
+  /**
+   * 新しいチームに移動するメンバーです。
+   */
+  newTeamMembers: TeamMemberInfo[];
+};
+
+/**
+ * チームメンバーを2つに分割します。
+ *
+ * @param members 分割するメンバーのリストです。
+ * @returns 分割結果を返します。
+ * @remarks メンバーはシャッフルしてから分割されます。5名の場合は3名と2名に分割されます。
+ */
+export const splitTeamMembers = (members: TeamMemberInfo[]): TeamSplitResult => {
+  // メンバーをシャッフル
+  const shuffled = [...members].sort(() => Math.random() - 0.5);
+
+  // 半分に分割（奇数の場合は元のチームに多めに残す）
+  const splitIndex = Math.ceil(shuffled.length / 2);
+  const originalTeamMembers = shuffled.slice(0, splitIndex);
+  const newTeamMembers = shuffled.slice(splitIndex);
+
+  return {
+    originalTeamMembers,
+    newTeamMembers,
+  };
+};
+
+/**
+ * 使用されていないチーム名の中から次の名前を生成します。
+ *
+ * @param usedNames 既に使用されているチーム名のリストです。
+ * @returns 使用されていない次のチーム名を返します。
+ * @throws {Error} 利用可能なチーム名がない場合にスローされます。
+ */
+export const generateNextTeamName = (usedNames: TeamName[]): TeamName => {
+  const alphabet = "abcdefghijklmnopqrstuvwxyz";
+  const usedSet = new Set(usedNames);
+
+  for (const letter of alphabet) {
+    const candidateName = TeamNameFactory(letter);
+    if (!usedSet.has(candidateName)) {
+      return candidateName;
+    }
+  }
+
+  throw new Error("利用可能なチーム名がありません。");
+};

--- a/packages/team/src/domain/team-consistency.ts
+++ b/packages/team/src/domain/team-consistency.ts
@@ -1,0 +1,128 @@
+import type { TeamId } from "./team";
+
+/**
+ * チームメンバー情報です。
+ */
+export type ParticipantInfo = {
+  /**
+   * 参加者の識別子です。
+   */
+  id: string;
+
+  /**
+   * 参加者の名前です。
+   */
+  name: string;
+};
+
+/**
+ * チームの整合性が保たれている状態です。
+ */
+export type TeamConsistencyOK = {
+  /**
+   * 結果タイプです。
+   */
+  type: "OK";
+};
+
+/**
+ * チームのメンバー数が最小人数（2名）を下回っている状態です。
+ */
+export type TeamUnderMinimum = {
+  /**
+   * 結果タイプです。
+   */
+  type: "TEAM_UNDER_MINIMUM";
+
+  /**
+   * 対象のチームIDです。
+   */
+  teamId: TeamId;
+
+  /**
+   * 現在のメンバー数です。
+   */
+  memberCount: number;
+
+  /**
+   * 残っているメンバーの情報です。
+   */
+  remainingMembers: ParticipantInfo[];
+};
+
+/**
+ * チームのメンバーが1名になり、合流が必要な状態です。
+ */
+export type TeamNeedsMerge = {
+  /**
+   * 結果タイプです。
+   */
+  type: "TEAM_NEEDS_MERGE";
+
+  /**
+   * 対象のチームIDです。
+   */
+  teamId: TeamId;
+
+  /**
+   * 合流先を探している参加者の情報です。
+   */
+  soleParticipant: ParticipantInfo;
+};
+
+/**
+ * 合流先のチームが存在しない状態です。
+ */
+export type NoMergeTarget = {
+  /**
+   * 結果タイプです。
+   */
+  type: "NO_MERGE_TARGET";
+
+  /**
+   * 合流先を探している参加者の情報です。
+   */
+  soleParticipant: ParticipantInfo;
+};
+
+/**
+ * チームのメンバー数が最大人数（4名）を超えている状態です。
+ */
+export type TeamOverMaximum = {
+  /**
+   * 結果タイプです。
+   */
+  type: "TEAM_OVER_MAXIMUM";
+
+  /**
+   * 対象のチームIDです。
+   */
+  teamId: TeamId;
+
+  /**
+   * 現在のメンバー数です。
+   */
+  memberCount: number;
+};
+
+/**
+ * チームの整合性チェックの結果を表す型です。
+ */
+export type TeamConsistencyCheckResult =
+  | TeamConsistencyOK
+  | TeamUnderMinimum
+  | TeamNeedsMerge
+  | NoMergeTarget
+  | TeamOverMaximum;
+
+/**
+ * チームの整合性が保たれているかどうかを判定します。
+ *
+ * @param result チームの整合性チェックの結果です。
+ * @returns 整合性が保たれている場合は true を、そうでない場合は false を返します。
+ */
+export const isTeamConsistencyOK = (
+  result: TeamConsistencyCheckResult,
+): result is TeamConsistencyOK => {
+  return result.type === "OK";
+};

--- a/packages/team/src/index.ts
+++ b/packages/team/src/index.ts
@@ -1,1 +1,3 @@
 export * from "./domain";
+export * from "./application";
+export * from "./infrastructure";

--- a/packages/team/src/infrastructure/adapter/index.ts
+++ b/packages/team/src/infrastructure/adapter/index.ts
@@ -1,0 +1,2 @@
+export * from "./team.drizzle.repository";
+export * from "./team-member-count.drizzle.query";

--- a/packages/team/src/infrastructure/adapter/team-member-count.drizzle.query.ts
+++ b/packages/team/src/infrastructure/adapter/team-member-count.drizzle.query.ts
@@ -1,0 +1,116 @@
+import type { Database } from "@ponp/fundamental";
+import { InfrastructureError } from "@ponp/fundamental";
+import { sql } from "drizzle-orm";
+
+import type { TeamMemberCountQuery } from "../../application/port/team-member-count.query";
+import { TeamId } from "../../domain";
+
+/**
+ * チームメンバー数クエリの依存関係です。
+ */
+type TeamMemberCountDrizzleQueryDependencies = { db: Database };
+
+/**
+ * チームメンバー数クエリの Drizzle ORM を使用した実装です。
+ *
+ * @param dependencies チームメンバー数クエリの依存関係です。
+ * @returns チームメンバー数クエリのインターフェースを実装したオブジェクトを返します。
+ * @remarks この実装は participant スキーマの participants テーブルを参照します。
+ */
+export const TeamMemberCountDrizzleQuery = (
+  dependencies: TeamMemberCountDrizzleQueryDependencies,
+): TeamMemberCountQuery => {
+  const { db } = dependencies;
+
+  return {
+    /**
+     * 全チームのメンバー数を取得します。
+     *
+     * @returns 全チームのメンバー数のリストを返します。
+     * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+     */
+    async getAllTeamMemberCounts() {
+      try {
+        const NIL_UUID = "00000000-0000-0000-0000-000000000000";
+        const result = await db.execute<{ team_id: string; count: string }>(sql`
+          SELECT
+            data->>'teamId' as team_id,
+            COUNT(*) as count
+          FROM participant.participants
+          WHERE data->>'teamId' != ${NIL_UUID}
+            AND data->>'status' = 'ACTIVE'
+          GROUP BY data->>'teamId'
+        `);
+
+        return result.rows.map((row) => ({
+          teamId: TeamId(row.team_id),
+          count: Number(row.count),
+        }));
+      } catch (error) {
+        throw new InfrastructureError("チームメンバー数の取得に失敗しました。", {
+          code: "TEAM_MEMBER_COUNT_QUERY_FAILED",
+          cause: error,
+        });
+      }
+    },
+
+    /**
+     * 指定したチームのメンバー数を取得します。
+     *
+     * @param teamId 取得するチームの識別子です。
+     * @returns チームのメンバー数を返します。
+     * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+     */
+    async getTeamMemberCount(teamId) {
+      try {
+        const result = await db.execute<{ count: string }>(sql`
+          SELECT COUNT(*) as count
+          FROM participant.participants
+          WHERE data->>'teamId' = ${teamId}
+            AND data->>'status' = 'ACTIVE'
+        `);
+
+        const row = result.rows[0];
+        return row ? Number(row.count) : 0;
+      } catch (error) {
+        throw new InfrastructureError("チームメンバー数の取得に失敗しました。", {
+          code: "TEAM_MEMBER_COUNT_QUERY_FAILED",
+          cause: error,
+        });
+      }
+    },
+
+    /**
+     * 指定したチームのメンバー一覧を取得します。
+     *
+     * @param teamId 取得するチームの識別子です。
+     * @returns チームメンバーのリストを返します。
+     * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+     */
+    async getTeamMembers(teamId) {
+      try {
+        const result = await db.execute<{
+          participant_id: string;
+          name: string;
+        }>(sql`
+          SELECT
+            data->>'id' as participant_id,
+            data->>'name' as name
+          FROM participant.participants
+          WHERE data->>'teamId' = ${teamId}
+            AND data->>'status' = 'ACTIVE'
+        `);
+
+        return result.rows.map((row) => ({
+          participantId: row.participant_id,
+          name: row.name,
+        }));
+      } catch (error) {
+        throw new InfrastructureError("チームメンバーの取得に失敗しました。", {
+          code: "TEAM_MEMBERS_QUERY_FAILED",
+          cause: error,
+        });
+      }
+    },
+  };
+};

--- a/packages/team/src/infrastructure/adapter/team.drizzle.repository.ts
+++ b/packages/team/src/infrastructure/adapter/team.drizzle.repository.ts
@@ -1,0 +1,90 @@
+import type { Database } from "@ponp/fundamental";
+import {
+  findAggregateTableById,
+  InfrastructureError,
+  upsertAggregateTable,
+} from "@ponp/fundamental";
+
+import type { TeamRepository } from "../../application/port/team.repository";
+import type { Team, TeamId } from "../../domain";
+import { Team as TeamEntity } from "../../domain";
+import { teamsTable } from "../db/schema";
+
+/**
+ * チームリポジトリの操作関数の依存関係です。
+ */
+type TeamDrizzleRepositoryDependencies = { db: Database };
+
+/**
+ * チームリポジトリの Drizzle ORM を使用した実装です。
+ *
+ * @param dependencies チームリポジトリの操作関数の依存関係です。
+ * @returns チームリポジトリのインターフェースを実装したオブジェクトを返します。
+ */
+export const TeamDrizzleRepository = (
+  dependencies: TeamDrizzleRepositoryDependencies,
+): TeamRepository => {
+  const { db } = dependencies;
+
+  return {
+    /**
+     * チームを保存します。
+     *
+     * @param team 保存するチームです。
+     * @throws {InfrastructureError} 保存に失敗した場合はエラーをスローします。
+     */
+    async save(team: Team) {
+      try {
+        await upsertAggregateTable(db, teamsTable, team);
+      } catch (error) {
+        throw new InfrastructureError("チームの保存に失敗しました。", {
+          code: "TEAM_SAVE_FAILED",
+          cause: error,
+        });
+      }
+    },
+
+    /**
+     * ID からチームを取得します。
+     *
+     * @param id 検索するチームの ID です。
+     * @returns 見つかった場合はチームを、存在しない場合は undefined を返します。
+     * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+     */
+    async findById(id: TeamId) {
+      try {
+        const record = await findAggregateTableById<Team>(db, teamsTable, id);
+        return record && TeamEntity.reconstruct(record);
+      } catch (error) {
+        throw new InfrastructureError("チームの取得に失敗しました。", {
+          code: "TEAM_FIND_BY_ID_FAILED",
+          cause: error,
+        });
+      }
+    },
+
+    /**
+     * すべてのチームを取得します。
+     *
+     * @returns 全チームのリストを返します。
+     * @throws {InfrastructureError} 取得に失敗した場合はエラーをスローします。
+     */
+    async findAll() {
+      try {
+        const records = await db
+          .select({ data: teamsTable.data })
+          .from(teamsTable)
+          .execute();
+
+        return records
+          .filter((record): record is { data: Team } => record.data !== null)
+          .map((record) => TeamEntity.reconstruct(record.data));
+      } catch (error) {
+        throw new InfrastructureError("チームの取得に失敗しました。", {
+          code: "TEAM_FIND_ALL_FAILED",
+          cause: error,
+        });
+      }
+    },
+  };
+};

--- a/packages/team/src/infrastructure/db/schema.ts
+++ b/packages/team/src/infrastructure/db/schema.ts
@@ -1,0 +1,21 @@
+import { jsonb, pgSchema, varchar } from "drizzle-orm/pg-core";
+
+/**
+ * チームコンテキストのデータを格納するスキーマです。
+ */
+export const teamSchema = pgSchema("team");
+
+/**
+ * チームテーブルです。
+ */
+export const teamsTable = teamSchema.table("teams", {
+  /**
+   * チームIDです。
+   */
+  id: varchar({ length: 36 }).primaryKey(),
+
+  /**
+   * チームに関するデータを JSONB で格納するカラムです。
+   */
+  data: jsonb(),
+});

--- a/packages/team/src/infrastructure/index.ts
+++ b/packages/team/src/infrastructure/index.ts
@@ -1,0 +1,2 @@
+export * from "./adapter";
+export * from "./db/schema";


### PR DESCRIPTION
## Summary

- 参加者の在籍ステータス（在籍中/休会中/退会済み）とチーム所属の整合性をチェックし、チーム人数が2〜4名に収まるよう自動で再編成する機能を実装
- メンバー離脱時（休会・退会）にチームが1名になった場合、自動的に他のチームへ合流
- メンバー復帰時に最小人数のチームに自動割当
- 管理者への通知機能（チーム最小人数警告、合流先なし警告）

## Test plan

- [x] ドメインサービスのユニットテスト (`team-assignment.service.test.ts`)
- [x] ユースケースのユニットテスト
  - `handle-member-leave.use-case.test.ts`
  - `handle-member-join.use-case.test.ts`
  - `split-team.use-case.test.ts`
- [x] 全テスト通過確認 (`pnpm test` - 134 tests passed)

🤖 Generated with [Claude Code](https://claude.ai/code)